### PR TITLE
countdown color by expiry duration

### DIFF
--- a/src/pages/Home.svelte
+++ b/src/pages/Home.svelte
@@ -18,6 +18,15 @@
 
     let percent = 0
     let circumference = 30 * 2 * Math.PI
+    const circumferenceColor = (seconds) => {
+      if (seconds <= 8) {
+        return 'red-500';
+      } else if (seconds <= 15) {
+        return 'yellow-500';
+      } else {
+        return 'green-500';
+      }
+    };
 
     // Start a timer
     setInterval(timer, 1000)
@@ -128,7 +137,7 @@
                     cy="40"
                   />
                   <circle
-                    class="text-green-500"
+                    class="text-{circumferenceColor(otpCountdown)}"
                     stroke-width="5"
                     stroke-dasharray="{circumference}"
                     stroke-dashoffset="{circumference - percent / 100 * circumference}"
@@ -208,7 +217,7 @@
             </div>
             <div class="flex justify-center ">
                 
-                <img alt="qr code" src="{qrURL}"/>
+                <img alt="qr code" src="{qrURL}" width="200" />
             </div>
         </div>
 

--- a/src/tools/totp.js
+++ b/src/tools/totp.js
@@ -23,7 +23,7 @@ function updateOtp(secret, secretType, otpLength, otpWindow) {
 }
 
 function getQRURL(secret, otpWindow, otpLength) {
-    return 'https://chart.googleapis.com/chart?chs=200x200&cht=qr&chl=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2FUser%3Fsecret%3D' + secret + '%26issuer%3DOTPNinja%26period%3D' + otpWindow + '%26digits%3D' + otpLength;
+    return 'https://chart.googleapis.com/chart?chs=400x400&cht=qr&chl=400x400&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2FUser%3Fsecret%3D' + secret + '%26issuer%3DOTPNinja%26period%3D' + otpWindow + '%26digits%3D' + otpLength;
 }
 
 const TOTP = {


### PR DESCRIPTION
This changes the countdown timer color based on how soon the token expires.

<img width="108" alt="Screenshot 2021-10-29 at 01 24 03" src="https://user-images.githubusercontent.com/552075/139344458-66d131d9-eeeb-4156-b24f-b08c963587bc.png">
<img width="108" alt="Screenshot 2021-10-29 at 01 23 46" src="https://user-images.githubusercontent.com/552075/139344462-4e06dc35-0944-4054-af5d-955b9bb04278.png">
<img width="97" alt="Screenshot 2021-10-29 at 01 23 57" src="https://user-images.githubusercontent.com/552075/139344466-a836c3c6-6786-4e17-a046-386d7e89ee7c.png">


Also bumped the resolution of the QR code images to `400x400px` while having them displayed at `200x200px` for a sharper image.